### PR TITLE
Fix missing parameter for define-obsolete-function-alias

### DIFF
--- a/core/libs/page-break-lines.el
+++ b/core/libs/page-break-lines.el
@@ -104,7 +104,7 @@ horizontal line of `page-break-string-char' characters."
   (page-break-lines--update-display-tables))
 
 ;;;###autoload
-(define-obsolete-function-alias 'turn-on-page-break-lines-mode 'page-break-lines-mode)
+(define-obsolete-function-alias 'turn-on-page-break-lines-mode 'page-break-lines-mode "2018-07-24")
 
 (dolist (hook '(window-configuration-change-hook
                 window-size-change-functions


### PR DESCRIPTION
The latest emacs 28 build requires `define-obsolete-function-alias` to have an additional "WHEN" parameter, so the spacemacs module does not work in doom with latest emacs. See https://github.com/hlissner/doom-emacs/issues/4534 for details.  