### PR TITLE
require core-configuration-layer to define needed function

### DIFF
--- a/layer/spacemacs-layouts/funcs.el
+++ b/layer/spacemacs-layouts/funcs.el
@@ -9,6 +9,8 @@
 ;;
 ;;; License: GPLv3
 
+(require 'core-configuration-layer) ; for configuration-layer/package-used-p
+
 
 ;; General Persp functions
 


### PR DESCRIPTION
On my emacs 29.1 on Ubuntu, the lack of this `require` cause failures when I try to setup layers from a file.