### PR TITLE
Revert "require core-configuration-layer to define needed function"

### DIFF
--- a/layer/spacemacs-layouts/funcs.el
+++ b/layer/spacemacs-layouts/funcs.el
@@ -9,8 +9,6 @@
 ;;
 ;;; License: GPLv3
 
-(require 'core-configuration-layer) ; for configuration-layer/package-used-p
-
 
 ;; General Persp functions
 


### PR DESCRIPTION
Reverts chenyanming/spacemacs_module_for_doom#16